### PR TITLE
Generate CSV from separated manifest files

### DIFF
--- a/deploy/bundle/Makefile
+++ b/deploy/bundle/Makefile
@@ -20,8 +20,10 @@ CSV=${MANIFEST_DIR}/deploymentvalidationoperator.clusterserviceversion.yaml
 all: image
 
 manifest:
-	mkdir -p ${MANIFEST_DIR}
-	oc process --local -o yaml --raw=true IMAGE=${OPERATOR_IMAGE} IMAGE_TAG=${OPERATOR_IMAGE_TAG} VERSION=${VERSION} REPLACE_VERSION=${REPLACE_VERSION} -f template/deploymentvalidationoperator.clusterserviceversion.yaml > ${CSV}
+	@mkdir -p $(MANIFEST_DIR) ; \
+	TEMPLATE=`mktemp` ; \
+	./generate-csv-template.py > $${TEMPLATE} ; \
+	oc process --local -o yaml --raw=true IMAGE=$(OPERATOR_IMAGE) IMAGE_TAG=$(OPERATOR_IMAGE_TAG) VERSION=$(VERSION) REPLACE_VERSION=$(REPLACE_VERSION) -f $${TEMPLATE} > $(CSV)
 
 bundle: manifest
 	docker build -t ${IMAGE}:${IMAGE_TAG} .

--- a/deploy/bundle/generate-csv-template.py
+++ b/deploy/bundle/generate-csv-template.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import datetime
+import os
+import sys
+import yaml
+import pathlib
+
+root = pathlib.Path(__file__).parent.absolute() / '../..'
+manifest_dir = root / 'deploy/openshift'
+csv_template_dir = root / 'deploy/bundle/template'
+
+with open(csv_template_dir / 'deploymentvalidationoperator.clusterserviceversion.yaml',
+        'r') as stream:
+    template = yaml.safe_load(stream)
+
+csv = template['objects'][0]
+
+csv['spec']['install']['spec']['clusterPermissions'] = []
+with open(manifest_dir / 'cluster-role.yaml', 'r') as stream:
+    operator_role = yaml.safe_load(stream)
+    csv['spec']['install']['spec']['clusterPermissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': 'deployment-validation-operator',
+        })
+
+csv['spec']['install']['spec']['permissions'] = []
+with open(manifest_dir / 'role.yaml', 'r') as stream:
+    operator_role = yaml.safe_load(stream)
+    csv['spec']['install']['spec']['permissions'].append(
+        {
+            'rules': operator_role['rules'],
+            'serviceAccountName': 'deployment-validation-operator',
+        })
+
+with open(manifest_dir / 'operator.yaml', 'r') as stream:
+    operator_components = []
+    operator = yaml.safe_load_all(stream)
+    for doc in operator:
+        operator_components.append(doc)
+    # There is only one yaml document in the operator deployment
+    operator_deployment = operator_components[0]
+    csv['spec']['install']['spec']['deployments'][0]['spec'] = \
+        operator_deployment['spec']
+
+csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = \
+    '${IMAGE}:${IMAGE_TAG}'
+
+now = datetime.datetime.now()
+csv['metadata']['annotations']['createdAt'] = \
+    now.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+yaml.dump(template, sys.stdout, default_flow_style=False)

--- a/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
+++ b/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
@@ -28,80 +28,11 @@ objects:
       spec:
         deployments:
         - name: deployment-validation-operator
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
-                k8s-app: deployment-validation-operator
-            strategy:
-              rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 0
-              type: RollingUpdate
-            template:
-              metadata:
-                labels:
-                  name: deployment-validation-operator
-                  k8s-app: deployment-validation-operator
-              spec:
-                containers:
-                - image: ${IMAGE}:${IMAGE_TAG}
-                  imagePullPolicy: Always
-                  name: deployment-validation-operator
-                  env:
-                  - name: WATCH_NAMESPACE
-                    value: ""
-                  - name: OPERATOR_NAME
-                    value: "deployment-validation-operator"
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
-                restartPolicy: Always
-                serviceAccount: deployment-validation-operator
-                terminationGracePeriodSeconds: 30
+          ### content of deploy/openshift/deployments.yaml
         clusterPermissions:
-        - rules:
-          - apiGroups:
-            - "*"
-            resources:
-            - "*"
-            verbs:
-            - get
-            - list
-            - watch
-          serviceAccountName: deployment-validation-operator
+          ### content of deploy/openshift/cluster-role.yaml
         permissions:
-        - rules:
-          - apiGroups:
-            - ""
-            resources:
-            - configmaps
-            - services
-            - services/finalizers
-            verbs:
-            - get
-            - create
-            - list
-            - delete
-            - update
-            - watch
-            - patch
-          - apiGroups:
-            - apps
-            resourceNames:
-            - deployment-validation-operator
-            resources:
-            - deployments/finalizers
-            verbs:
-            - update
-          - apiGroups:
-            - monitoring.coreos.com
-            resources:
-            - servicemonitors
-            verbs:
-            - '*'
-          serviceAccountName: deployment-validation-operator
+        ### content of deploy/openshift/role.yaml
       strategy: deployment
     installModes:
     - supported: true

--- a/deploy/openshift/cluster-role-binding.yaml
+++ b/deploy/openshift/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: deployment-validation-operator
+subjects:
+- kind: ServiceAccount
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator
+roleRef:
+  kind: ClusterRole
+  name: deployment-validation-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/openshift/cluster-role.yaml
+++ b/deploy/openshift/cluster-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: deployment-validation-operator
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: deployment-validation-operator
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deployment-validation-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: deployment-validation-operator
+        app: deployment-validation-operator
+    spec:
+      containers:
+      - image: quay.io/deployment-validation-operator/dv-operator:latest
+        imagePullPolicy: Always
+        name: deployment-validation-operator
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: OPERATOR_NAME
+          value: "deployment-validation-operator"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      restartPolicy: Always
+      serviceAccount: deployment-validation-operator
+      terminationGracePeriodSeconds: 30
+      resources:
+        requests:
+          memory: "200Mi"
+          cpu: "100m"
+        limits:
+          memory: "400Mi"
+          cpu: "200m"

--- a/deploy/openshift/role-binding.yaml
+++ b/deploy/openshift/role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator
+subjects:
+- kind: ServiceAccount
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator
+roleRef:
+  kind: Role
+  name: deployment-validation-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/openshift/role.yaml
+++ b/deploy/openshift/role.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  - services/finalizers
+  verbs:
+  - get
+  - create
+  - list
+  - delete
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - apps
+  resourceNames:
+  - deployment-validation-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - '*'

--- a/deploy/openshift/service-account.yaml
+++ b/deploy/openshift/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployment-validation-operator
+  namespace: deployment-validation-operator


### PR DESCRIPTION
In this way we can use the manifests to install the operator without the
whole OLM infrastructure.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>