### PR TITLE
Rename repo to deployment-validation-operator

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,11 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-ENV OPERATOR=/usr/local/bin/dv-operator \
+ENV OPERATOR=/usr/local/bin/deployment-validation-operator \
     USER_UID=1001 \
-    USER_NAME=dv-operator
+    USER_NAME=deployment-validation-operator
 
 # install operator binary
-COPY build/_output/bin/dv-operator ${OPERATOR}
+COPY build/_output/bin/deployment-validation-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -16,10 +16,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
-	dv_config "github.com/app-sre/dv-operator/config"
-	"github.com/app-sre/dv-operator/pkg/apis"
-	"github.com/app-sre/dv-operator/pkg/controller"
-	"github.com/app-sre/dv-operator/version"
+	dv_config "github.com/app-sre/deployment-validation-operator/config"
+	"github.com/app-sre/deployment-validation-operator/pkg/apis"
+	"github.com/app-sre/deployment-validation-operator/pkg/controller"
+	"github.com/app-sre/deployment-validation-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -43,7 +43,7 @@ var (
 	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
 )
-var log = logf.Log.WithName("DeploymentValidator")
+var log = logf.Log.WithName("DeploymentValidation")
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
@@ -93,7 +93,7 @@ func main() {
 
 	ctx := context.TODO()
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "dv-operator-lock")
+	err = leader.Become(ctx, "deployment-validation-operator-lock")
 	if err != nil {
 		log.Error(err, "Failed to get leader lock")
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,9 @@
 package config
 
 const (
-	// OperatorName stores the name used by this code for the Deployment Validator Operator
-	OperatorName string = "dv-operator"
+	// OperatorName stores the name used by this code for the Deployment Validation Operator
+	OperatorName string = "deployment-validation-operator"
 
 	// OperatorNamespace stores a string indicating the Kubernetes namespace in which the operator runs
-	OperatorNamespace string = "dv-operator"
+	OperatorNamespace string = "deployment-validation-operator"
 )

--- a/deploy/bundle/Makefile
+++ b/deploy/bundle/Makefile
@@ -7,7 +7,7 @@ IMAGE_TAG=latest
 endif
 
 ifndef OPERATOR_IMAGE
-OPERATOR_IMAGE=quay.io/deployment-validation-operator/dv-operator
+OPERATOR_IMAGE=quay.io/deployment-validation-operator/deployment-validation-operator
 endif
 
 ifndef OPERATOR_IMAGE_TAG

--- a/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
+++ b/deploy/bundle/template/deploymentvalidationoperator.clusterserviceversion.yaml
@@ -14,13 +14,13 @@ objects:
       containerImage: ${IMAGE}:${IMAGE_TAG}
       createdAt: 08/25/2020
       support: Best Effort
-      repository: https://github.com/app-sre/dv-operator
+      repository: https://github.com/app-sre/deployment-validation-operator
       description: |-
         The deployment validation operator
     name: deployment-validation-operator.v${VERSION}
     namespace: placeholder
   spec:
-    description: 'The Deployment Validator Operator for Kubernetes monitors workloads
+    description: 'The Deployment Validation Operator for Kubernetes monitors workloads
       on a cluster a provides suggestions for best practices.
       '
     displayName: Deployment Validation Operator
@@ -50,7 +50,7 @@ objects:
       operated-by: deployment-validation-operator
     links:
     - name: repository
-      url: https://github.com/app-sre/dv-operator
+      url: https://github.com/app-sre/deployment-validation-operator
     - name: containerImage
       url: https://${IMAGE}:${IMAGE_TAG}
     maturity: alpha
@@ -64,7 +64,7 @@ objects:
     version: ${VERSION}
 parameters:
 - name: IMAGE
-  value: "quay.io/deployment-validation-operator/dv-operator"
+  value: "quay.io/deployment-validation-operator/deployment-validation-operator"
 - name: IMAGE_TAG
   value: "latest"
 - name: VERSION

--- a/deploy/openshift/operator.yaml
+++ b/deploy/openshift/operator.yaml
@@ -22,7 +22,7 @@ spec:
         app: deployment-validation-operator
     spec:
       containers:
-      - image: quay.io/deployment-validation-operator/dv-operator:latest
+      - image: quay.io/deployment-validation-operator/deployment-validation-operator:latest
         imagePullPolicy: Always
         name: deployment-validation-operator
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/app-sre/dv-operator
+module github.com/app-sre/deployment-validation-operator
 
 go 1.13
 

--- a/pkg/controller/generic_reconciler.go
+++ b/pkg/controller/generic_reconciler.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/app-sre/dv-operator/pkg/validations"
+	"github.com/app-sre/deployment-validation-operator/pkg/validations"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controller/generic_reconciler_test.go
+++ b/pkg/controller/generic_reconciler_test.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"testing"
 
-	"github.com/app-sre/dv-operator/pkg/testutils"
+	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/pkg/validations/base_test.go
+++ b/pkg/validations/base_test.go
@@ -3,7 +3,7 @@ package validations
 import (
 	"testing"
 
-	"github.com/app-sre/dv-operator/pkg/testutils"
+	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/pkg/validations/replicas_test.go
+++ b/pkg/validations/replicas_test.go
@@ -3,8 +3,8 @@ package validations
 import (
 	"testing"
 
-	"github.com/app-sre/dv-operator/pkg/testutils"
-	dv_tu "github.com/app-sre/dv-operator/pkg/testutils"
+	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
+	dv_tu "github.com/app-sre/deployment-validation-operator/pkg/testutils"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_tu "github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/validations/requests_limits_test.go
+++ b/pkg/validations/requests_limits_test.go
@@ -3,8 +3,8 @@ package validations
 import (
 	"testing"
 
-	"github.com/app-sre/dv-operator/pkg/testutils"
-	dv_tu "github.com/app-sre/dv-operator/pkg/testutils"
+	"github.com/app-sre/deployment-validation-operator/pkg/testutils"
+	dv_tu "github.com/app-sre/deployment-validation-operator/pkg/testutils"
 	"github.com/prometheus/client_golang/prometheus"
 	prom_tu "github.com/prometheus/client_golang/prometheus/testutil"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/validations/utils.go
+++ b/pkg/validations/utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/app-sre/dv-operator/config"
+	"github.com/app-sre/deployment-validation-operator/config"
 	"github.com/prometheus/client_golang/prometheus"
 )
 


### PR DESCRIPTION
While dv-operator is shorter, it does not tell anything about the
purpose of the operator. The convention of openshift operators is to
have long and descriptive names, so let's follow it.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>